### PR TITLE
Fix chart indicators disappearing in fullscreen

### DIFF
--- a/components/TradingViewWidget.tsx
+++ b/components/TradingViewWidget.tsx
@@ -32,12 +32,11 @@ const TradingViewWidget = ({ title, scriptUrl, config, height = 600, className, 
 
     const widgetConfig = {
         ...config,
-        height: currentHeight,
         width: "100%",
         autosize: true,
     };
 
-    const containerRef = useTradingViewWidget(scriptUrl, widgetConfig, currentHeight);
+    const containerRef = useTradingViewWidget(scriptUrl, widgetConfig);
 
     const toggleExpand = () => {
         setIsExpanded(!isExpanded);
@@ -63,9 +62,11 @@ const TradingViewWidget = ({ title, scriptUrl, config, height = 600, className, 
                     </Button>
                 )}
 
-                <div className={cn('tradingview-widget-container', className, isExpanded && "h-full")} ref={containerRef}>
-                    <div className="tradingview-widget-container__widget" style={{ height: currentHeight, width: "100%" }} />
-                </div>
+                <div
+                    className={cn('tradingview-widget-container', className, isExpanded && "h-full")}
+                    ref={containerRef}
+                    style={{ height: currentHeight, width: "100%" }}
+                />
             </div>
         </div>
     );

--- a/components/TradingViewWidget.tsx
+++ b/components/TradingViewWidget.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { memo, useState, useEffect } from 'react';
+import React, { memo, useState } from 'react';
 import useTradingViewWidget from "@/hooks/useTradingViewWidget";
 import { cn } from "@/lib/utils";
 import { Maximize2, Minimize2 } from 'lucide-react';
@@ -17,18 +17,6 @@ interface TradingViewWidgetProps {
 
 const TradingViewWidget = ({ title, scriptUrl, config, height = 600, className, allowExpand = false }: TradingViewWidgetProps) => {
     const [isExpanded, setIsExpanded] = useState(false);
-    const [windowHeight, setWindowHeight] = useState(0);
-
-    useEffect(() => {
-        if (typeof window !== 'undefined') {
-            setWindowHeight(window.innerHeight);
-            const handleResize = () => setWindowHeight(window.innerHeight);
-            window.addEventListener('resize', handleResize);
-            return () => window.removeEventListener('resize', handleResize);
-        }
-    }, []);
-
-    const currentHeight = isExpanded ? windowHeight : height;
 
     const widgetConfig = {
         ...config,
@@ -65,7 +53,7 @@ const TradingViewWidget = ({ title, scriptUrl, config, height = 600, className, 
                 <div
                     className={cn('tradingview-widget-container', className, isExpanded && "h-full")}
                     ref={containerRef}
-                    style={{ height: currentHeight, width: "100%" }}
+                    style={{ height: isExpanded ? '100vh' : height, width: "100%" }}
                 />
             </div>
         </div>

--- a/hooks/useTradingViewWidget.tsx
+++ b/hooks/useTradingViewWidget.tsx
@@ -1,35 +1,30 @@
 'use client';
 import { useEffect, useRef } from "react";
 
-const useTradingViewWidget = (scriptUrl: string, config: Record<string, unknown>, height: number | string = 600) => {
+const useTradingViewWidget = (scriptUrl: string, config: Record<string, unknown>) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
+    const serializedConfig = JSON.stringify(config);
 
     useEffect(() => {
-        if (!containerRef.current) return;
+        const container = containerRef.current;
+        if (!container) return;
 
         // Clean up previous instance
-        containerRef.current.innerHTML = '';
+        container.innerHTML = '';
 
-        // Create wrapper with dynamic height support
-        // If autosize is true in config, we want 100% height/width
-        const isAutosize = config.autosize === true;
-        const styleHeight = isAutosize ? '100%' : `${height}px`;
-
-        containerRef.current.innerHTML = `<div class="tradingview-widget-container__widget" style="width: 100%; height: ${styleHeight};"></div>`;
+        container.innerHTML = '<div class="tradingview-widget-container__widget" style="width: 100%; height: 100%;"></div>';
 
         const script = document.createElement("script");
         script.src = scriptUrl;
         script.async = true;
-        script.innerHTML = JSON.stringify(config);
+        script.innerHTML = serializedConfig;
 
-        containerRef.current.appendChild(script);
+        container.appendChild(script);
 
         return () => {
-            if (containerRef.current) {
-                containerRef.current.innerHTML = '';
-            }
+            container.innerHTML = '';
         }
-    }, [scriptUrl, JSON.stringify(config), height]) // Use stringified config to avoid ref issues
+    }, [scriptUrl, serializedConfig])
 
     return containerRef;
 }


### PR DESCRIPTION
## Summary
- keep TradingView chart widgets mounted when toggling fullscreen
- resize the existing widget container instead of reinitializing the embed, which preserves indicator state
- use viewport height in fullscreen mode so the widget never initializes against a zero-height container

## Test plan
- npx eslint components/TradingViewWidget.tsx hooks/useTradingViewWidget.tsx
- npx tsc --noEmit (currently fails on pre-existing errors in lib/inngest/functions.ts; not caused by this change)

Fixes Open-Dev-Society/OpenStock#49

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TradingView widget height rendering to properly display at full viewport dimensions when expanded.

* **Refactor**
  * Simplified widget configuration and initialization by removing unnecessary resize event listeners and redundant state management, improving code efficiency and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->