### PR TITLE
Override Taiwan country label

### DIFF
--- a/components/forms/CountrySelectField.tsx
+++ b/components/forms/CountrySelectField.tsx
@@ -26,6 +26,11 @@ const COUNTRY_LABEL_OVERRIDES: Record<string, string> = {
     TW: 'Taiwan',
 };
 
+const COUNTRY_OPTIONS = countryList().getData().map((country) => ({
+    ...country,
+    label: COUNTRY_LABEL_OVERRIDES[country.value] ?? country.label,
+}));
+
 type CountrySelectProps = {
     name: string;
     label: string;
@@ -42,12 +47,6 @@ const CountrySelect = ({
     onChange: (value: string) => void;
 }) => {
     const [open, setOpen] = useState(false);
-
-    // Get country options with flags
-    const countries = countryList().getData().map((country) => ({
-        ...country,
-        label: COUNTRY_LABEL_OVERRIDES[country.value] ?? country.label,
-    }));
 
     // Helper function to get flag emoji
     const getFlagEmoji = (countryCode: string) => {
@@ -70,7 +69,7 @@ const CountrySelect = ({
                     {value ? (
                         <span className='flex items-center gap-2'>
               <span>{getFlagEmoji(value)}</span>
-              <span>{countries.find((c) => c.value === value)?.label}</span>
+              <span>{COUNTRY_OPTIONS.find((c) => c.value === value)?.label}</span>
             </span>
                     ) : (
                         'Select your country...'
@@ -92,7 +91,7 @@ const CountrySelect = ({
                     </CommandEmpty>
                     <CommandList className='max-h-60 bg-gray-800 scrollbar-hide-default'>
                         <CommandGroup className='bg-gray-800'>
-                            {countries.map((country) => (
+                            {COUNTRY_OPTIONS.map((country) => (
                                 <CommandItem
                                     key={country.value}
                                     value={`${country.label} ${country.value}`}

--- a/components/forms/CountrySelectField.tsx
+++ b/components/forms/CountrySelectField.tsx
@@ -22,6 +22,10 @@ import { Check, ChevronsUpDown } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import countryList from 'react-select-country-list';
 
+const COUNTRY_LABEL_OVERRIDES: Record<string, string> = {
+    TW: 'Taiwan',
+};
+
 type CountrySelectProps = {
     name: string;
     label: string;
@@ -40,7 +44,10 @@ const CountrySelect = ({
     const [open, setOpen] = useState(false);
 
     // Get country options with flags
-    const countries = countryList().getData();
+    const countries = countryList().getData().map((country) => ({
+        ...country,
+        label: COUNTRY_LABEL_OVERRIDES[country.value] ?? country.label,
+    }));
 
     // Helper function to get flag emoji
     const getFlagEmoji = (countryCode: string) => {


### PR DESCRIPTION
## Summary
- override the signup country label for TW to display Taiwan
- keep the existing country list library and only adjust the rendered label for that entry

## Test plan
- npx eslint components/forms/CountrySelectField.tsx

Fixes Open-Dev-Society/OpenStock#34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed country label display so overridden names (e.g., Taiwan) show correctly and consistently in both the dropdown and the selected value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->