### PR TITLE
Set the Turbopack project root

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,9 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
     devIndicators: false,
+    turbopack: {
+        root: process.cwd(),
+    },
     /* config options here */
     images: {
         remotePatterns: [


### PR DESCRIPTION
## Summary
- set the Next.js Turbopack root to the project directory explicitly
- prevent parent lockfiles from being inferred as the workspace root during local dev

## Test plan
- npx eslint next.config.ts
- reviewed the config diff to confirm it only pins Turbopack to process.cwd()

Fixes Open-Dev-Society/OpenStock#39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for improved build performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->