### PR TITLE
fix: prevent "NaN" market cap in watchlist when Finnhub omits the value

### DIFF
--- a/__tests__/utils.test.ts
+++ b/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
     formatChangePercent,
     getChangeColorClass,
     calculateNewsDistribution,
+    formatNumber,
 } from '@/lib/utils';
 
 describe('formatSymbolForTradingView', () => {
@@ -184,6 +185,25 @@ describe('getChangeColorClass', () => {
 
     it('returns red for negative', () => {
         expect(getChangeColorClass(-0.5)).toBe('text-red-500');
+    });
+});
+
+describe('formatNumber', () => {
+    // Finnhub's profile2 marketCapitalization is expressed in millions of USD,
+    // which formatNumber scales up by 1e6.
+    it('formats market caps (input in millions) into T/B/M/K suffixes', () => {
+        expect(formatNumber(3_000_000)).toBe('3.00T'); // 3,000,000M => $3T
+        expect(formatNumber(150_000)).toBe('150.00B'); // 150,000M => $150B
+        expect(formatNumber(150)).toBe('150.00M'); // 150M => $150M
+    });
+
+    it('returns N/A for missing or non-finite market caps', () => {
+        // Finnhub omits marketCapitalization for many symbols (e.g. ETFs); the
+        // watchlist passes that value straight through, so it must not render "NaN".
+        expect(formatNumber(undefined)).toBe('N/A');
+        expect(formatNumber(null)).toBe('N/A');
+        expect(formatNumber(NaN)).toBe('N/A');
+        expect(formatNumber(Infinity)).toBe('N/A');
     });
 });
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -119,7 +119,11 @@ export const formatPrice = (price: number) => {
 // Alias for consistency
 export const formatCurrency = formatPrice;
 
-export function formatNumber(num: number): string {
+export function formatNumber(num?: number | null): string {
+    // Guard against missing/invalid market caps (Finnhub omits this field for many
+    // symbols, e.g. ETFs). Without this, `num * 1e6` yields NaN and renders "NaN".
+    if (num === undefined || num === null || !Number.isFinite(num)) return 'N/A';
+
     // If number is small (likely already in millions from Finnhub), multiply by 1M to get actual value
     // Typical mega-cap is > 100B. 100B in millions is 100,000.
     // If we assume typical market cap input IS millions:


### PR DESCRIPTION
## Bug

The watchlist table renders the literal string **`NaN`** in the Market Cap column for any stock whose market cap is unavailable.

`formatNumber` (lib/utils.ts) computes `num * 1e6` and formats the result. But `getWatchlistData` (lib/actions/finnhub.actions.ts) passes the value straight through:

```ts
marketCap: profile?.marketCapitalization,   // number | undefined
```

Finnhub's `/stock/profile2` endpoint omits `marketCapitalization` for many symbols (ETFs and a lot of non-US tickers). When it's missing, `formatNumber(undefined)` evaluates `undefined * 1e6 → NaN`, falls through every `value >= …` branch, and returns `NaN.toString()` → `"NaN"`, which `WatchlistTable.tsx` renders directly:

```tsx
<td className="px-6 py-4 text-gray-400 font-medium">
    {formatNumber(stock.marketCap)}
</td>
```

## Reproduction

```js
formatNumber(undefined) // => "NaN"  (rendered in the Market Cap cell)
formatNumber(NaN)       // => "NaN"
```

The included regression test asserts this and **fails before** the fix:

```
AssertionError: expected 'NaN' to be 'N/A'
```

## Fix

Guard against `undefined` / `null` / non-finite input and return `'N/A'` — the same convention already used by the sibling helper `formatMarketCapValue`. The parameter type is widened to `number | null | undefined` to reflect what actually reaches the function on the watchlist call path. No other behavior changes; the existing millions-scaling logic is untouched.

## Regression test

Added a `formatNumber` block to `__tests__/utils.test.ts` covering:
- the normal millions-scaled path (`3_000_000 → "3.00T"`, `150_000 → "150.00B"`, `150 → "150.00M"`)
- the missing / non-finite path (`undefined`, `null`, `NaN`, `Infinity` → `"N/A"`)

`npm test` is green (81 passed, 4 pre-existing skips). Confirmed the new test fails before the fix and passes after.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number formatting to gracefully handle missing, null, or invalid market data by displaying "N/A" instead of potential errors, ensuring more stable and reliable data presentation throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->