### PR TITLE
feat(ai-provider): default MiniMax to the current MiniMax-M3 model

### DIFF
--- a/__tests__/ai-provider.integration.test.ts
+++ b/__tests__/ai-provider.integration.test.ts
@@ -10,7 +10,7 @@ import { callAIProvider } from "@/lib/ai-provider";
 describe.skipIf(!process.env.MINIMAX_API_KEY)(
   "MiniMax integration",
   () => {
-    it("generates a response from MiniMax M2.7", async () => {
+    it("generates a response from MiniMax M3", async () => {
       const result = await callAIProvider(
         "Reply with exactly: MINIMAX_OK",
         "minimax"

--- a/__tests__/ai-provider.test.ts
+++ b/__tests__/ai-provider.test.ts
@@ -29,7 +29,7 @@ describe("getProviderConfig", () => {
     const config = getProviderConfig("minimax");
     expect(config.name).toBe("minimax");
     expect(config.baseUrl).toBe("https://api.minimax.io/v1");
-    expect(config.model).toBe("MiniMax-M2.7");
+    expect(config.model).toBe("MiniMax-M3");
     expect(config.apiKey).toBe("test-key");
   });
 
@@ -176,7 +176,7 @@ describe("callAIProvider", () => {
       "Bearer test-minimax-key"
     );
     const body = JSON.parse(options.body);
-    expect(body.model).toBe("MiniMax-M2.7");
+    expect(body.model).toBe("MiniMax-M3");
     expect(body.messages[0].content).toBe("test prompt");
     expect(body.temperature).toBe(0.7);
   });

--- a/lib/ai-provider.ts
+++ b/lib/ai-provider.ts
@@ -36,7 +36,9 @@ export function getProviderConfig(
         apiKey: process.env.MINIMAX_API_KEY || "",
         baseUrl:
           process.env.MINIMAX_BASE_URL || "https://api.minimax.io/v1",
-        model: process.env.MINIMAX_MODEL || "MiniMax-M2.7",
+        // Defaults to the current MiniMax-M3 model. Set MINIMAX_MODEL to
+        // select another model (e.g. the previous MiniMax-M2.7).
+        model: process.env.MINIMAX_MODEL || "MiniMax-M3",
       };
 
     case "siray":


### PR DESCRIPTION
Reason: The MiniMax provider still defaulted to a superseded model and did not expose the current MiniMax-M3 model.

## What changed

- `lib/ai-provider.ts`: the MiniMax provider now defaults to the current `MiniMax-M3` model instead of the previous one. The `MINIMAX_MODEL` environment variable still overrides the default, so the earlier `MiniMax-M2.7` model remains selectable.
- `__tests__/ai-provider.test.ts`: updated the two assertions that pinned the default MiniMax model so they expect `MiniMax-M3`.
- `__tests__/ai-provider.integration.test.ts`: updated the integration test title to reference `MiniMax-M3`.

The change follows the existing provider pattern: a single string default that can be overridden via `MINIMAX_MODEL`. No endpoint, base URL, or request-shape changes were made.

## Checks

- `npm test` — 79 passed, 4 skipped (live-key integration tests).
- `npx eslint lib/ai-provider.ts __tests__/ai-provider.test.ts __tests__/ai-provider.integration.test.ts` — 0 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default MiniMax model to MiniMax-M3.
  * Existing configuration options can still override the default model.

* **Tests**
  * Updated provider and integration coverage to validate MiniMax-M3 requests and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->